### PR TITLE
Travisdouce/retrieve list of available factories from home

### DIFF
--- a/lib/remote_factory_girl.rb
+++ b/lib/remote_factory_girl.rb
@@ -9,24 +9,22 @@ require 'remote_factory_girl/json_to_active_resource'
 module RemoteFactoryGirl
   class RemoteFactoryGirl
 
-    attr_reader :name, :attributes, :config
+    attr_reader :config, :response
 
-    def initialize(name, attributes, config)
-      @name       = name
-      @attributes = attributes
-      @config     = config
+    def initialize(config)
+      @config = config
     end
 
     def apply_config(config_applier = ConfigApplier)
-      config_applier.apply_config(post.json, config.to_hash)
+      config_applier.apply_config(response.to_hash, config.to_hash)
     end
 
-    def post(http = Http)
-      @post ||= http.post(config, params)
+    def create(factory, attributes = {}, http = Http)
+      @response ||= http.post(config, { factory: factory, attributes: attributes })
     end
 
-    def params
-      { factory: name, attributes: attributes }
+    def factories(attributes = {}, http = Http)
+      @response ||= http.get(config, attributes)
     end
   end
 
@@ -35,9 +33,14 @@ module RemoteFactoryGirl
     self.config = opts.fetch(:config).configure(config)
   end
 
+  def self.factories(params = {}, http = Http)
+    factory = RemoteFactoryGirl.new(config)
+    factory.factories(params, http).to_hash
+  end
+
   def self.create(factory, attributes = {}, config_applier = ConfigApplier, http = Http)
-    factory = RemoteFactoryGirl.new(factory, attributes, config)
-    factory.post(http)
+    factory = RemoteFactoryGirl.new(config)
+    factory.create(factory, attributes, http)
     factory.apply_config(config_applier)
   end
 

--- a/lib/remote_factory_girl.rb
+++ b/lib/remote_factory_girl.rb
@@ -38,9 +38,9 @@ module RemoteFactoryGirl
     factory.factories(params, http).to_hash
   end
 
-  def self.create(factory, attributes = {}, config_applier = ConfigApplier, http = Http)
+  def self.create(factory_name, attributes = {}, config_applier = ConfigApplier, http = Http)
     factory = RemoteFactoryGirl.new(config)
-    factory.create(factory, attributes, http)
+    factory.create(factory_name, attributes, http)
     factory.apply_config(config_applier)
   end
 

--- a/lib/remote_factory_girl/http.rb
+++ b/lib/remote_factory_girl/http.rb
@@ -20,7 +20,7 @@ module RemoteFactoryGirl
     end
 
     def get
-      @response_json = http_lib.get config.home_url, params, content_type: :json, accept: :json
+      @response_json = http_lib.get config.home_url, params.merge!(content_type: :json, accept: :json)
       self
     end
 

--- a/lib/remote_factory_girl/http.rb
+++ b/lib/remote_factory_girl/http.rb
@@ -3,10 +3,14 @@ require 'rest-client'
 module RemoteFactoryGirl
   class Http
     def self.post(config, params, http_lib = RestClient)
-      new(config, params, http_lib).response
+      new(config, params, http_lib).post
     end
 
-    attr_reader :config, :params, :http_lib
+    def self.get(config, params, http_lib = RestClient)
+      new(config, params, http_lib).get
+    end
+
+    attr_reader :config, :params, :http_lib, :response_json
 
     def initialize(config, params, http_lib = RestClient)
       @config   = config
@@ -14,18 +18,19 @@ module RemoteFactoryGirl
       @http_lib = http_lib
     end
 
-    def response
-      post
+    def get
+      @response_json = http_lib.get config.home_url, params, content_type: :json, accept: :json
       self
     end
 
     def post
       config.raise_no_host_error
-      @post ||= http_lib.post config.home_url, params, content_type: :json, accept: :json
+      @response_json = http_lib.post config.home_url, params, content_type: :json, accept: :json
+      self
     end
 
-    def json 
-      @json ||= JSON.parse(post)
+    def to_hash
+      JSON.parse(response_json)
     end
   end
 end

--- a/lib/remote_factory_girl/http.rb
+++ b/lib/remote_factory_girl/http.rb
@@ -13,6 +13,7 @@ module RemoteFactoryGirl
     attr_reader :config, :params, :http_lib, :response_json
 
     def initialize(config, params, http_lib = RestClient)
+      config.raise_no_host_error
       @config   = config
       @params   = params
       @http_lib = http_lib
@@ -24,7 +25,6 @@ module RemoteFactoryGirl
     end
 
     def post
-      config.raise_no_host_error
       @response_json = http_lib.post config.home_url, params, content_type: :json, accept: :json
       self
     end

--- a/spec/integration/remote_factory_girl_spec.rb
+++ b/spec/integration/remote_factory_girl_spec.rb
@@ -61,6 +61,16 @@ describe RemoteFactoryGirl do
 
     before do
       RestClient.stub(:post).and_return('{"user": {"id": "1", "first_name": "Sam", "last_name": "Iam"}}')
+      RestClient.stub(:get).and_return('["user", "user_admin"]')
+    end
+
+    describe '.factories' do
+
+      before { RemoteFactoryGirl.config.home[:host] = 'localhost' }
+
+      it 'should return all factories available' do
+        expect(RemoteFactoryGirl.factories).to match_array(['user', 'user_admin'])
+      end
     end
 
     describe '.create' do

--- a/spec/models/remote_factory_girl_spec.rb
+++ b/spec/models/remote_factory_girl_spec.rb
@@ -4,19 +4,12 @@ describe RemoteFactoryGirl do
 
   let(:config) { double('config', :to_hash => {}) }
 
-  it 'should return params for http request' do
-    rfg = RemoteFactoryGirl::RemoteFactoryGirl.new('user', { :first_name => 'Sam' }, config)
-    expect(rfg.params).to eq(
-      { :factory => 'user', :attributes => { :first_name => 'Sam'}}
-    )
-  end
-
-  describe '#post' do
+  describe '#create' do
     it 'should send a post request' do
       http       = double('RemoteFactoryGirl::Http')
       attributes = { :first_name => 'Sam' }
       expect(http).to receive(:post).with(config, {:factory => 'user', :attributes => { :first_name => 'Sam'}})
-      RemoteFactoryGirl::RemoteFactoryGirl.new('user', attributes, config).post(http)
+      RemoteFactoryGirl::RemoteFactoryGirl.new(config).create('user', attributes, http)
     end
   end
 
@@ -24,10 +17,12 @@ describe RemoteFactoryGirl do
     it 'should apply config options to json with supplied configuration' do
       attributes     = { :first_name => 'Sam' }
       config_applier = double('RemoteFactoryGirl::ConfigApplier')
-      post           = double('RemoteFactoryGirl::Http', :json => {})
-      RemoteFactoryGirl::Http.stub(:post).and_return(post)
-      expect(config_applier).to receive(:apply_config).with(post.json, config.to_hash)
-      RemoteFactoryGirl::RemoteFactoryGirl.new('user', attributes, config).apply_config(config_applier)
+      response       = double('RemoteFactoryGirl::Http', :to_hash => {})
+      RemoteFactoryGirl::Http.stub(:post).and_return(response)
+      expect(config_applier).to receive(:apply_config).with(response.to_hash, config.to_hash)
+      remote_factory_girl = RemoteFactoryGirl::RemoteFactoryGirl.new(config)
+      remote_factory_girl.create('user', attributes)
+      remote_factory_girl.apply_config(config_applier)
     end
   end
 


### PR DESCRIPTION
Adds ability to retrieve a list of factories available in _home_ by invoking `RemoteFactoryGirl#factories`.  This is particularly useful when the _client_ developer does not have access to _home_'s source code and can not search for available factories for themselves (i.e. a mobile application developer perhaps).
