### PR TITLE
Removes RemoteFactoryGirl#apply_config

### DIFF
--- a/lib/remote_factory_girl.rb
+++ b/lib/remote_factory_girl.rb
@@ -15,10 +15,6 @@ module RemoteFactoryGirl
       @config = config
     end
 
-    def apply_config(config_applier = ConfigApplier)
-      config_applier.apply_config(response.to_hash, config.to_hash)
-    end
-
     def create(factory, attributes = {}, http = Http)
       @response ||= http.post(config, { factory: factory, attributes: attributes })
     end
@@ -41,7 +37,7 @@ module RemoteFactoryGirl
   def self.create(factory_name, attributes = {}, config_applier = ConfigApplier, http = Http)
     factory = RemoteFactoryGirl.new(config)
     factory.create(factory_name, attributes, http)
-    factory.apply_config(config_applier)
+    config_applier.apply_config(factory.response.to_hash, config.to_hash)
   end
 
   def self.config

--- a/spec/models/remote_factory_girl_spec.rb
+++ b/spec/models/remote_factory_girl_spec.rb
@@ -13,19 +13,6 @@ describe RemoteFactoryGirl do
     end
   end
 
-  describe '#apply_config' do
-    it 'should apply config options to json with supplied configuration' do
-      attributes     = { :first_name => 'Sam' }
-      config_applier = double('RemoteFactoryGirl::ConfigApplier')
-      response       = double('RemoteFactoryGirl::Http', :to_hash => {})
-      RemoteFactoryGirl::Http.stub(:post).and_return(response)
-      expect(config_applier).to receive(:apply_config).with(response.to_hash, config.to_hash)
-      remote_factory_girl = RemoteFactoryGirl::RemoteFactoryGirl.new(config)
-      remote_factory_girl.create('user', attributes)
-      remote_factory_girl.apply_config(config_applier)
-    end
-  end
-
   it 'should be able to configure with a block' do
     pending
   end


### PR DESCRIPTION
RemoteFactoryGirl#apply_config does not need to be part of the
RemoteFactoryGirl interface
