### PR TITLE
Configures returning json without root when json has not root

### DIFF
--- a/lib/remote_factory_girl/config_applier.rb
+++ b/lib/remote_factory_girl/config_applier.rb
@@ -2,6 +2,7 @@ require 'remote_factory_girl/hash_to_dot'
 require 'remote_factory_girl/json_to_active_resource'
 require 'ostruct'
 require 'json'
+require 'remote_factory_girl/factory_girl_json_parser'
 
 module  RemoteFactoryGirl
   class ConfigApplier 
@@ -23,7 +24,8 @@ module  RemoteFactoryGirl
 
     def default_config
       { :hash_to_dot_klass             => HashToDot, 
-        :json_to_active_resource_klass => JsonToActiveResource }
+        :json_to_active_resource_klass => JsonToActiveResource,
+        :response_parser               => FactoryGirlJsonParser }
     end
 
     private
@@ -42,8 +44,8 @@ module  RemoteFactoryGirl
       config[:return_response_as] == :dot_notation ? config[:hash_to_dot_klass].convert(parsed_json) : parsed_json
     end
 
-    def return_with_root(parsed_json)
-      config[:return_with_root] == false ? Array(parsed_json).flatten.last : parsed_json
+    def return_with_root(response_hash)
+      config[:return_with_root] == false ? config[:response_parser].without_root(response_hash) : response_hash
     end
   end
 end

--- a/lib/remote_factory_girl/factory_girl_json_parser.rb
+++ b/lib/remote_factory_girl/factory_girl_json_parser.rb
@@ -1,0 +1,29 @@
+module  RemoteFactoryGirl
+  class FactoryGirlJsonParser
+
+    def self.without_root(response_hash)
+      new(response_hash).without_root
+    end
+
+    attr_reader :response_hash
+
+    def initialize(response_hash)
+      @response_hash = response_hash
+    end
+
+    def without_root
+      has_root_key? ? response_array.last : response_hash
+    end
+
+    private
+
+    def has_root_key?
+      response_array.length == 2 && response_array.last.is_a?(Hash)
+    end
+
+    def response_array
+      @response_array ||= Array(response_hash).flatten
+    end
+  end
+end
+

--- a/lib/remote_factory_girl/factory_girl_json_parser.rb
+++ b/lib/remote_factory_girl/factory_girl_json_parser.rb
@@ -1,4 +1,4 @@
-module  RemoteFactoryGirl
+module RemoteFactoryGirl
   class FactoryGirlJsonParser
 
     def self.without_root(response_hash)

--- a/spec/models/remote_factory_girl/config_applier_spec.rb
+++ b/spec/models/remote_factory_girl/config_applier_spec.rb
@@ -13,17 +13,35 @@ describe RemoteFactoryGirl::ConfigApplier do
     }
     let(:hash_to_dot_klass)      { double('RemoteFactoryGirl::HashToDot') }
     let(:dish_json_with_user)    { OpenStruct.new(:user => OpenStruct.new(:first_name => 'Sam', :last_name => 'Iam')) }
-    let(:dish_json_without_user) { OpenStruct.new(:first_name => 'Sam', :last_name => 'Iam') }
+    let(:dot_notation_without_root) { OpenStruct.new(:first_name => 'Sam', :last_name => 'Iam') }
 
     describe '.apply_config' do
-      it 'should not return root hash key when .return_with_root is false' do
-        response = RemoteFactoryGirl::ConfigApplier.apply_config(json, :return_with_root => false)
-        expect(response).to_not have_key(:user) 
+      describe 'when configured to return root key' do
+        it 'should return a hash with a root key when initialized with a hash that has a root key' do
+          response = RemoteFactoryGirl::ConfigApplier.apply_config(json, :with_root => true)
+
+          expect(response).to have_key(:user)
+        end
       end
 
-      it 'should not return root hash key when .return_with_root is false' do
-        response = RemoteFactoryGirl::ConfigApplier.apply_config(json, :with_root => true)
-        expect(response).to have_key(:user)
+      describe 'when configured to not return root key' do
+
+        let(:factory_girl_json_parser) { double('RemoteFactoryGirl::FactoryGirlJsonParser', without_root: { :first_name => 'Sam', :last_name => 'Iam'}) }
+
+        it 'should not return a hash with a root key when initialized with a hash that has a root key' do
+          response = RemoteFactoryGirl::ConfigApplier.apply_config(json, :return_with_root => false,
+                                                                         :factory_girl_json_parser => factory_girl_json_parser)
+
+          expect(response).to_not have_key(:user)
+          expect(response[:first_name]).to eq('Sam')
+        end
+
+        it 'should not return a hash with a root key when initialized with a hash that does not have a root key' do
+          hash_without_root_key = { :first_name => 'Sam', :last_name => 'Iam'}
+          response              = RemoteFactoryGirl::ConfigApplier.apply_config(hash_without_root_key, :return_with_root => false,
+                                                                                                       :factory_girl_json_parser => factory_girl_json_parser)
+          expect(response[:first_name]).to eq('Sam')
+        end
       end
 
       it 'should return an object that responds to dot notation' do
@@ -34,10 +52,12 @@ describe RemoteFactoryGirl::ConfigApplier do
       end
 
       it 'should not return root hash key and should return an object that responds to dot notation' do
-        hash_to_dot_klass.stub(:convert).and_return(dish_json_without_user)
+        factory_girl_json_parser = double('RemoteFactoryGirl::FactoryGirlJsonParser', without_root: { :first_name => 'Sam', :last_name => 'Iam'})
+        hash_to_dot_klass.stub(:convert).and_return(dot_notation_without_root)
         response = RemoteFactoryGirl::ConfigApplier.apply_config(json, :return_response_as => :dot_notation, 
                                                                        :return_with_root   => false,
-                                                                       :hash_to_dot_klass  => hash_to_dot_klass)
+                                                                       :hash_to_dot_klass  => hash_to_dot_klass,
+                                                                       :factory_girl_json_parser => factory_girl_json_parser)
         expect(response.first_name).to eq('Sam') 
       end
     end

--- a/spec/models/remote_factory_girl/factory_girl_json_parser_spec.rb
+++ b/spec/models/remote_factory_girl/factory_girl_json_parser_spec.rb
@@ -1,0 +1,22 @@
+require 'remote_factory_girl/factory_girl_json_parser'
+
+describe RemoteFactoryGirl::FactoryGirlJsonParser do
+
+  let(:hash_with_root)    { { :user => { :first_name => 'Sam', :last_name => 'Iam' }} }
+  let(:hash_without_root) { { :first_name => 'Sam', :last_name => 'Iam' } }
+
+  describe '.without_root' do
+    it 'should return a hash without a root key when given a hash with a root key' do
+      without_root = RemoteFactoryGirl::FactoryGirlJsonParser.without_root(hash_with_root)
+
+      expect(without_root).to_not have_key(:user)
+      expect(without_root[:first_name]).to eq('Sam')
+    end
+
+    it 'should return a hash without a root key when given a hash without a root key' do
+      without_root = RemoteFactoryGirl::FactoryGirlJsonParser.without_root(hash_with_root)
+
+      expect(without_root).to_not have_key('user')
+    end
+  end
+end


### PR DESCRIPTION
RemoteFactoryGirl did not return a properly formatted json
representation of a factory when:
1. It was configured to not return a root key, and
2. When the json representation of the factory returned from _home_ did
   not contain a root key.

This commit returns a properly formatted json representation of a
factory when the json returned from _home_ contains a root key and when
the json returned from _home_ does not contain a root key.

The json response returned from RemoteFactoryGirlHomeRails is a json
representation of a factory that was requested to be created in the
_client_. In some circumstances (possibly the version of FactoryGirl
used in _home_ or possibly how the factory is defined), the json
representation contains a root key and in some circumstances the json
does not contain a root key.

The following is a json representation of a factory that contains a
root key:

``` json
{"user": {"first_name": "Sam", "last_name": "Iam"}}
```

The following is a json representation of a factory that does NOT
contain a root key:

``` json
{"first_name": "Sam", "last_name": "Iam"}
```

When RemoteFactoryGirl was configured to not return a root key and the
json representation of a factory returned from _home_ did not contain a
root key then the json returned from RemoteFactoryGirl was not correct.
Given the example json above, it would incorrectly return:

`Iam`

although it was supposed to return:

``` json
{"first_name": "Sam", "last_name": "Iam"}
```
